### PR TITLE
Pages

### DIFF
--- a/components/api.js
+++ b/components/api.js
@@ -23,7 +23,7 @@ const get_notification_urls = (all=false) => {
 					return x[1]
 				}
 			})
-			return [main_url, ...urls]
+			return [main_url, ...new Set(urls)]
 		}
 		return [main_url]
 	})

--- a/components/api.js
+++ b/components/api.js
@@ -2,19 +2,47 @@ const fetch = require('node-fetch')
 const { foreach } = require('./helpers')
 
 const auth = { 'Authorization': 'token ' + process.env.GITHUB_TOKEN }
-const get_notifications = () => fetch('https://api.github.com/notifications', { //?all=true', {
-	headers: { ...auth }
-}).then(res => res.json())
+
+const get_notifications = (all=false) => fetch('https://api.github.com/notifications' + (all ? '?all=true' : ''), {
+	headers: { ...auth },
+}).then((res) => res.json())
+
+const head_notifications = (all=false) => fetch('https://api.github.com/notifications' + (all ? '?all=true' : ''), {
+	method: 'HEAD',
+	headers: { ...auth },
+})
+
+const get_notification_urls = (all=false) => {
+	const main_url = 'https://api.github.com/notifications' + (all ? '?all=true' : '')
+	return head_notifications().then((res) => {
+		const link = res.headers.get("Link")
+		if( link ){
+			const urls = link.split(', ').map(rel => {
+				x = rel.match(/\<([^>]+)\>; rel="[^"]+"/)
+				if(x && x.length >= 1){
+					return x[1]
+				}
+			})
+			return [main_url, ...urls]
+		}
+		return [main_url]
+	})
+}
+
+const get_url = (url, options) => fetch(url, {
+	headers: { ...auth },
+	...options
+})
 
 const graphql = (query, variables={}) => fetch('https://api.github.com/graphql', {
 	body: JSON.stringify({ query, variables }),
 	method: 'POST',
-	headers: { ...auth }
+	headers: { ...auth },
 }).then(res => res.json())
 
 const patch_notification = (thread) => fetch(`https://api.github.com/notifications/threads/${thread}`, {
 	method: 'PATCH',
-	headers: { ...auth }
+	headers: { ...auth },
 })
 
 const build_agenda = (json) => {
@@ -173,7 +201,10 @@ const build_graphql_mutation = (node_id) => {
 }
 
 module.exports = {
+	get_url,
+	get_notification_urls,
 	get_notifications,
+	head_notifications,
 	patch_notification,
 	graphql,
 	build_agenda,

--- a/components/helpers.js
+++ b/components/helpers.js
@@ -25,6 +25,17 @@ const dateFormat = (d) => {
 	return moment(d).fromNow()
 }
 
+/* // not yet used, will use for chunking notification loads via graphql
+Object.defineProperty(Array.prototype, 'chunk', {
+    value: function(chunkSize) {
+        var that = this
+        return Array(Math.ceil(that.length/chunkSize)).fill().map(function(_,i){
+            return that.slice(i*chunkSize,i*chunkSize+chunkSize)
+        })
+    }
+})
+*/
+
 module.exports = {
 	foreach: (object, func) => {
 		for( const [ key, value ] of Object.entries(object) ){

--- a/views/AgendaView.js
+++ b/views/AgendaView.js
@@ -109,6 +109,11 @@ class AgendaView {
 			'updated_at',
 		]
 		this.setupScreen()
+		this.model.statusbar = (text) => {
+			this.loader.stop()
+			this.loader.load(text)
+			this.loader.setFront()
+		}
 	}
 
 	reduceItem(repo_id, n_id) {


### PR DESCRIPTION
In response to #5 loading multiple pages has been implemented in the following manner:

- Make an initial HEAD call to `/notifications`
- Use the unique URL values of `Link: ` header (if present) as additional URLs
- For each URL, use the result of calling GET to get GraphQL data to merge into local storage
- Finally, store locally, align stars, and return control to the user

This should result in as few as one and as many as three calls to each of REST and GraphQL.